### PR TITLE
Return from computational exception signal handler

### DIFF
--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -598,10 +598,10 @@ static void pushsig(void)
 
 #  ifdef OPENSSL_SYS_WIN32
     savsig[SIGABRT] = signal(SIGABRT, recsig);
-    savsig[SIGFPE] = signal(SIGFPE, recsig);
-    savsig[SIGILL] = signal(SIGILL, recsig);
+    savsig[SIGFPE] = signal(SIGFPE, SIG_DFL);
+    savsig[SIGILL] = signal(SIGILL, SIG_DFL);
     savsig[SIGINT] = signal(SIGINT, recsig);
-    savsig[SIGSEGV] = signal(SIGSEGV, recsig);
+    savsig[SIGSEGV] = signal(SIGSEGV, SIG_DFL);
     savsig[SIGTERM] = signal(SIGTERM, recsig);
 #  else
     for (i = 1; i < NX509_SIG; i++) {


### PR DESCRIPTION
SEI CMU CERT C rule SIG35-C: Do not return from a computational signal handler
Returning from a signal handler for SIGFPE, SIGILL and SIGSEGV results in undefined behaviour according to the C Standard.
The function recsig returns after setting intr_signal so should not be used for handling SIGFPE, SIGILL and SIGSEGV.
Furthermore, read_string_inner does not check intr_signal for SIGFPE, SIGILL or SIGSEGV.
Signal handler for SIGFPE, SIGILL and SIGSEGV changed from recsig to SIG_DFL in sigpush.
Violation discovered using Parasoft analyzer.
CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
